### PR TITLE
Added a gemspec and pushed the resulting gem

### DIFF
--- a/jekyll-xml-source.gemspec
+++ b/jekyll-xml-source.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |s|
+    s.name        = 'jekyll-xml-source'
+    s.version     = '0.1.0'
+    s.date        = '2018-07-07'
+    s.summary     = "A plugin that will download XML from external sites."
+    s.description = "Jekyll XML Source is a plugin that will download XML from external sites and makes the data available when generating a site. It also works for RSS feeds. Once downloaded it is converted to JSON."
+    s.authors     = ["Derek Smart"]
+    s.email       = 'derek@grindaga.com'
+    s.files       = ["jekyll_xml_source.rb"]
+    s.homepage    = 'https://github.com/mcred/jekyll-xml-source/'
+    s.license       = 'MIT'
+  end

--- a/jekyll-xml-source.gemspec
+++ b/jekyll-xml-source.gemspec
@@ -9,4 +9,6 @@ Gem::Specification.new do |s|
     s.files       = ["jekyll_xml_source.rb"]
     s.homepage    = 'https://github.com/mcred/jekyll-xml-source/'
     s.license       = 'MIT'
+    s.add_runtime_dependency 'json'
+    s.add_runtime_dependency 'activesupport'
   end

--- a/jekyll-xml-source.gemspec
+++ b/jekyll-xml-source.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
     s.name        = 'jekyll-xml-source'
-    s.version     = '0.1.0'
+    s.version     = '0.1.1'
     s.date        = '2018-07-07'
     s.summary     = "A plugin that will download XML from external sites."
     s.description = "Jekyll XML Source is a plugin that will download XML from external sites and makes the data available when generating a site. It also works for RSS feeds. Once downloaded it is converted to JSON."


### PR DESCRIPTION
I have pushed this to https://rubygems.org/gems/jekyll-xml-source

## Issues Addressed

Fixes the lack of a gemspec to create a gem to allow easy reuse of this module through Jekyll's usage of gems.

## Proposed Changes

Added a gemspec as per https://github.com/jekyll/jekyll/pull/7114#issuecomment-403319492

## Testing

No testing required as it doesn't alter module behaviour.