### PR TITLE
Fix `uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState` error

### DIFF
--- a/jekyll_xml_source.rb
+++ b/jekyll_xml_source.rb
@@ -8,6 +8,7 @@
 
 require 'json'
 require 'net/http'
+require 'active_support/isolated_execution_state'
 require 'active_support/core_ext/hash'
 
 module Jekyll_Xml_Source


### PR DESCRIPTION
## Issues Addressed

This may be just a `osx`/`osx-arm64` issue, but I couldn't build my website locally which relies on this plugin. The error I was having was `uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState`

![image](https://user-images.githubusercontent.com/15052188/148978669-3d2aa021-b865-4162-a882-b86df25b0b0d.png)

## Proposed Changes

I've just found that `require`ing this gem fixes the issue. Inspired by this, https://github.com/rails/rails/issues/43889.

## Testing

I can now build my website locally, so this fix seems to have worked
